### PR TITLE
- Adding support to bundle k8s config into a bake variable

### DIFF
--- a/tasks/serve/task.json
+++ b/tasks/serve/task.json
@@ -59,6 +59,24 @@
             "groupName": "env"
         },
         {
+            "name": "useKubernetes",
+            "type": "boolean",
+            "label": "Deployment Regions",
+            "required": true,
+            "helpMarkDown": "Bundle the kubernetes config (must run k8 task login first) into the deployment",
+            "groupName": "env"
+        },
+        {
+            "name": "configToken",
+            "type": "string",
+            "label": "Deployment Regions",
+            "required": false,
+            "helpMarkDown": "name of the BAKE varibale to store the kube config content",
+            "groupName": "env",
+            "defaultValue": "k8s_config",
+            "visibleRule":"useKubernetes = true"
+        },
+        {
             "name": "recipe",
             "type": "string",
             "label": "Bake Recipe Docker Tag",


### PR DESCRIPTION
- K8s ingredient requires config data as a base64 string
- Assumes the ADO k8s task is run first, with the login command