### PR TITLE
Fix lowercase image tags

### DIFF
--- a/tasks/mix/index.ts
+++ b/tasks/mix/index.ts
@@ -134,6 +134,7 @@ export class clitask {
                     {
                         //write the artifact file if set.
                         if (useArtifact){
+                            artifactTag = artifactTag.toLocaleLowerCase();
                             console.log('Generating artifact file against image tag ' + artifactTag)
 
                             tl.mkdirP(artifactOutput)

--- a/tasks/serve/index.ts
+++ b/tasks/serve/index.ts
@@ -42,6 +42,8 @@ export class clitask {
             console.log('Deploying Bake recipe via Artifact output | ' + recipe)
         }        
 
+        recipe = recipe.toLocaleLowerCase()
+
         /*RegEx to determine if it is local or remote Docker Registry
         let remoteRegistry = recipe.match(/(.*)[\/.*]/)
         let login = tl.tool('docker')


### PR DESCRIPTION
Fixing mix/serve to force images and tags to always be lower case  (feature branch SEMVER might be mixed case)