### PR TITLE
[HOTFIX] Bump extension version to 1.0.1 for next publish

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "azure-bake",
   "name": "Azure Bake Tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "HomecareHomebase",
   "icons": {
     "default": "tools-icon.png"


### PR DESCRIPTION
The marketplace already has extension version 1.0.1. The `--rev-version` flag in `tfx extension publish` increments the version in `vss-extension.json` before publishing.\n\nCurrently `vss-extension.json` says `1.0.0`, so `--rev-version` bumps it to `1.0.1` which already exists → publish fails.\n\nThis sets it to `1.0.1` so the next publish goes to `1.0.2` with the Node handler fix from PR #71.\n\n**Merge immediately to unblock the hotfix publish.**